### PR TITLE
feat: add org profile README and sync workflow

### DIFF
--- a/.github/workflows/sync-profile.yml
+++ b/.github/workflows/sync-profile.yml
@@ -1,0 +1,44 @@
+name: Sync Profile README
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - profile/README.md
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.CELEB_GITHUB_ACTIONS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CELEB_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
+          owner: medit-platform
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync to .github-private
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          CONTENT=$(base64 < profile/README.md)
+          SHA=$(gh api repos/medit-platform/.github-private/contents/profile/README.md --jq '.sha' 2>/dev/null || echo "")
+
+          if [ -n "$SHA" ]; then
+            gh api repos/medit-platform/.github-private/contents/profile/README.md \
+              -X PUT \
+              --field message="chore: sync profile README" \
+              --field content="$CONTENT" \
+              --field sha="$SHA"
+          else
+            gh api repos/medit-platform/.github-private/contents/profile/README.md \
+              -X PUT \
+              --field message="chore: sync profile README" \
+              --field content="$CONTENT"
+          fi

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,29 @@
+# medit platform
+
+의료 환경에서 동작하는 3D 뷰어 및 플랫폼 소프트웨어를 개발합니다.
+
+## Packages
+
+| Package | Description |
+| - | - |
+| [renderer](https://github.com/medit-platform/renderer) | 3D 렌더링 엔진 |
+| [nitro](https://github.com/medit-platform/nitro) | 고성능 데이터 처리 |
+| [nitro-renderer](https://github.com/medit-platform/nitro-renderer) | Nitro 기반 렌더러 |
+| [react-components](https://github.com/medit-platform/react-components) | 공통 UI 컴포넌트 |
+| [toolkit](https://github.com/medit-platform/toolkit) | 공통 유틸리티 |
+| [react-use](https://github.com/medit-platform/react-use) | 공통 React 훅 |
+
+## Apps
+
+| App | Description |
+| - | - |
+| [auravue](https://github.com/medit-platform/auravue) | 웹 뷰어 앱 |
+| [checkpoint](https://github.com/medit-platform/checkpoint) | 체크포인트 앱 |
+| [cx-suite](https://github.com/medit-platform/cx-suite) | CX Suite 앱 |
+
+## Resources
+
+| | |
+| - | - |
+| [Package Status Dashboard](https://fantastic-umbrella-p3yv6jq.pages.github.io/) | 각 앱이 사용 중인 패키지 버전 현황 |
+| [github-actions](https://github.com/medit-platform/github-actions) | 공통 워크플로우 |


### PR DESCRIPTION
## Problems :mag:

 - github.com/medit-platform 조직 페이지가 비어있어 팀 내부 리소스 접근이 불편함
 - 공개용/멤버용 프로필 README를 별도 관리해 수정 시 두 곳을 모두 업데이트해야 함

## Causes :bulb:

 - .github 레포에 profile/README.md 미존재
 - 멤버용 README는 별도 .github-private 레포에 위치해 동기화 수단이 없었음

## Changes :memo:

 - `profile/README.md` 추가: 패키지, 앱 목록, 주요 링크(대시보드, github-actions) 포함
 - `.github/workflows/sync-profile.yml` 추가: master 브랜치에 profile/README.md 변경 시 .github-private 레포에 자동 동기화

## Testing :test_tube:

 - [ ] github.com/medit-platform 공개 프로필 페이지에서 README 노출 확인
 - [ ] 멤버 로그인 후 조직 Overview에서 README 노출 확인
 - [ ] profile/README.md 수정 후 .github-private에 자동 반영 확인

## Screenshots :camera:

| Before | After |
| - | - |
| 1 | 2 |